### PR TITLE
Namespace Gracenote HTTP class

### DIFF
--- a/lib/gracenote.rb
+++ b/lib/gracenote.rb
@@ -252,7 +252,7 @@ class Gracenote
   # Arguments:
   #   query
   def api (query)
-    return HTTP.post(@apiURL, query)
+    return Gracenote::HTTP.post(@apiURL, query)
   end
   
   # Function: constructQueryReq

--- a/lib/gracenote/HTTP.rb
+++ b/lib/gracenote/HTTP.rb
@@ -9,33 +9,35 @@ require 'curb'
 require 'rack'
 require 'uri'
 
-class HTTP
-  def self.get(path, cookie='')
-    uri = URI(path)
-    req = Net::HTTP.new(uri.host, uri.port)
-    req.read_timeout = 60
-    req.use_ssl = (uri.scheme == "https") ? true : false
-    headers = {'Cookie' => cookie}
-    
-    resp = req.get( uri.path, headers)
-    return resp
-  end
-  
-  def self.post(path, data='', cookie='')
-    uri = URI(path)
-    req = Net::HTTP.new(uri.host, uri.port)
-    req.read_timeout = 60
-    req.use_ssl = (uri.scheme == "https") ? true : false
-    headers = {'Cookie' => cookie, "Content-Type" => "application/xml"}
+class Gracenote
+  class HTTP
+    def self.get(path, cookie='')
+      uri = URI(path)
+      req = Net::HTTP.new(uri.host, uri.port)
+      req.read_timeout = 60
+      req.use_ssl = (uri.scheme == "https") ? true : false
+      headers = {'Cookie' => cookie}
 
-    if data.class.to_s == 'String'
-      reqdata = data;
-    else
-      reqdata = Rack::Utils.build_nested_query(data)
+      resp = req.get( uri.path, headers)
+      return resp
     end
 
-    resp = req.request_post( uri.path, reqdata, headers)     
-    return resp
-  end
+    def self.post(path, data='', cookie='')
+      uri = URI(path)
+      req = Net::HTTP.new(uri.host, uri.port)
+      req.read_timeout = 60
+      req.use_ssl = (uri.scheme == "https") ? true : false
+      headers = {'Cookie' => cookie, "Content-Type" => "application/xml"}
 
+      if data.class.to_s == 'String'
+        reqdata = data;
+      else
+        reqdata = Rack::Utils.build_nested_query(data)
+      end
+
+      resp = req.request_post( uri.path, reqdata, headers)
+      return resp
+    end
+
+  end
 end

--- a/spec/lib/gracenote/HTTP_spec.rb
+++ b/spec/lib/gracenote/HTTP_spec.rb
@@ -2,10 +2,10 @@ require (File.expand_path('./../../../spec_helper', __FILE__))
 
 describe "HTTP" do
   it "must have a get method" do
-    HTTP.should respond_to :get
+    Gracenote::HTTP.should respond_to :get
   end
 
   it "must have a post method" do
-    HTTP.should respond_to :post
+    Gracenote::HTTP.should respond_to :post
   end
 end


### PR DESCRIPTION
Currently the `HTTP` class will conflict when used in an application that also uses `net/http`, and `net/http` is loaded first. This update namespaces the `HTTP` implementation specific to Gracenote to avoid the conflict.
